### PR TITLE
IE 541 Get coda docs specs passing on master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+/.idea/
 
 # Used by dotenv library to load environment variables.
 .env
@@ -52,3 +53,6 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+.mise.toml
+.tool-versions
+.rubyversion

--- a/spec/cassettes/account/whoami.yml
+++ b/spec/cassettes/account/whoami.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://coda.io/apis/v1beta1/whoami
+    uri: https://coda.io/apis/v1/whoami
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/columns/all.yml
+++ b/spec/cassettes/columns/all.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns
+    uri: https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns
     body:
       encoding: US-ASCII
       string: ''
@@ -37,8 +37,8 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: '{"items":[{"id":"c-BWoZD1pDLj","type":"column","name":"Column 1","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-BWoZD1pDLj","display":true,"format":{"type":"text","isArray":false}},{"id":"c-mIEcSkQvey","type":"column","name":"Column
-        2","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-mIEcSkQvey","format":{"type":"text","isArray":false}}],"href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns?limit=100"}'
-    http_version: 
+      string: '{"items":[{"id":"c-BWoZD1pDLj","type":"column","name":"Column 1","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-BWoZD1pDLj","display":true,"format":{"type":"text","isArray":false}},{"id":"c-mIEcSkQvey","type":"column","name":"Column
+        2","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-mIEcSkQvey","format":{"type":"text","isArray":false}}],"href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns?limit=100"}'
+    http_version:
   recorded_at: Fri, 10 Jan 2020 00:04:29 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/columns/find.yml
+++ b/spec/cassettes/columns/find.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-BWoZD1pDLj
+    uri: https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-BWoZD1pDLj
     body:
       encoding: US-ASCII
       string: ''
@@ -37,8 +37,8 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: '{"id":"c-BWoZD1pDLj","type":"column","name":"Column 1","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-BWoZD1pDLj","display":true,"format":{"type":"text","isArray":false},"parent":{"id":"grid-7wlFDEirg4","type":"table","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4","browserLink":"https://coda.io/d/_dYuypr0WRkq#_tugrid-7wlFDEirg4","name":"Test
+      string: '{"id":"c-BWoZD1pDLj","type":"column","name":"Column 1","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-BWoZD1pDLj","display":true,"format":{"type":"text","isArray":false},"parent":{"id":"grid-7wlFDEirg4","type":"table","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4","browserLink":"https://coda.io/d/_dYuypr0WRkq#_tugrid-7wlFDEirg4","name":"Test
         Table 1"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Jan 2020 00:10:40 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/docs/create.yml
+++ b/spec/cassettes/docs/create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://coda.io/apis/v1beta1/docs
+    uri: https://coda.io/apis/v1/docs
     body:
       encoding: UTF-8
       string: '{"title":"Untitled","sourceDoc":null,"timezone":"America/Los_Angeles","folderId":null}'
@@ -37,8 +37,8 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: '{"id":"Yuypr0WRkq","type":"doc","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq","browserLink":"https://coda.io/d/_dYuypr0WRkq","name":"Untitled","owner":"ojewaleolaide@gmail.com","ownerName":"ojewale
+      string: '{"id":"Yuypr0WRkq","type":"doc","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq","browserLink":"https://coda.io/d/_dYuypr0WRkq","name":"Untitled","owner":"ojewaleolaide@gmail.com","ownerName":"ojewale
         olaide","createdAt":"2020-01-09T23:23:09.301Z","updatedAt":"2020-01-09T23:23:09.370Z"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Jan 2020 23:23:09 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/tables/all.yml
+++ b/spec/cassettes/tables/all.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables
+    uri: https://coda.io/apis/v1/docs/Yuypr0WRkq/tables
     body:
       encoding: US-ASCII
       string: ''
@@ -37,9 +37,9 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: '{"items":[{"id":"grid-7wlFDEirg4","type":"table","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4","browserLink":"https://coda.io/d/_dYuypr0WRkq#_tugrid-7wlFDEirg4","name":"Test
-        Table 1","parent":{"id":"canvas-rkGK12KYgt","type":"section","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/sections/canvas-rkGK12KYgt","browserLink":"https://coda.io/d/_dYuypr0WRkq/_suYgt","name":"Section
-        1"}}],"href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables?limit=100"}'
-    http_version: 
+      string: '{"items":[{"id":"grid-7wlFDEirg4","type":"table","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4","browserLink":"https://coda.io/d/_dYuypr0WRkq#_tugrid-7wlFDEirg4","name":"Test
+        Table 1","parent":{"id":"canvas-rkGK12KYgt","type":"section","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/sections/canvas-rkGK12KYgt","browserLink":"https://coda.io/d/_dYuypr0WRkq/_suYgt","name":"Section
+        1"}}],"href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables?limit=100"}'
+    http_version:
   recorded_at: Thu, 09 Jan 2020 23:54:11 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/tables/find.yml
+++ b/spec/cassettes/tables/find.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4
+    uri: https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4
     body:
       encoding: US-ASCII
       string: ''
@@ -37,8 +37,8 @@ http_interactions:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: '{"id":"grid-7wlFDEirg4","type":"table","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4","browserLink":"https://coda.io/d/_dYuypr0WRkq#_tugrid-7wlFDEirg4","name":"Test
-        Table 1","displayColumn":{"id":"c-BWoZD1pDLj","type":"column","href":"https://coda.io/apis/v1beta1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-BWoZD1pDLj"},"rowCount":3,"createdAt":"2020-01-09T23:25:06.174Z","updatedAt":"2020-01-09T23:25:32.437Z","sorts":[],"layout":"default"}'
-    http_version: 
+      string: '{"id":"grid-7wlFDEirg4","type":"table","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4","browserLink":"https://coda.io/d/_dYuypr0WRkq#_tugrid-7wlFDEirg4","name":"Test
+        Table 1","displayColumn":{"id":"c-BWoZD1pDLj","type":"column","href":"https://coda.io/apis/v1/docs/Yuypr0WRkq/tables/grid-7wlFDEirg4/columns/c-BWoZD1pDLj"},"rowCount":3,"createdAt":"2020-01-09T23:25:06.174Z","updatedAt":"2020-01-09T23:25:32.437Z","sorts":[],"layout":"default"}'
+    http_version:
   recorded_at: Fri, 10 Jan 2020 00:02:14 GMT
 recorded_with: VCR 5.0.0

--- a/spec/entities/columns_spec.rb
+++ b/spec/entities/columns_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CodaDocs::Entities::Columns do
 
   before do
     @columns = VCR.use_cassette('columns/all') {
-      subject.all(doc_id: doc_id, table_id: table_id)
+      subject.all(doc_id, table_id)
     }
   end
 
@@ -22,7 +22,7 @@ RSpec.describe CodaDocs::Entities::Columns do
     column_id = @columns.first['id']
 
     res = VCR.use_cassette('columns/find') {
-      subject.find(doc_id: doc_id, table_id: table_id, column_id: column_id)
+      subject.find(doc_id, table_id, column_id)
     }
 
     expect(res['type']).to eq 'column'

--- a/spec/entities/tables_spec.rb
+++ b/spec/entities/tables_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CodaDocs::Entities::Tables do
 
   it 'finds a table in a document' do
     res = VCR.use_cassette('tables/find') {
-      subject.find(doc_id: doc_id, table_id: table_id)
+      subject.find(doc_id, table_id)
     }
 
     expect(res['name']).not_to be nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,4 +12,7 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  ENV['CODA_DOCS_API_KEY'] ||= 'dummy_api_key'
+  ENV['STATIC_TABLE_ID'] ||= 'grid-7wlFDEirg4'
 end

--- a/spec/support/spec_entities_creator.rb
+++ b/spec/support/spec_entities_creator.rb
@@ -5,7 +5,7 @@ class SpecEntitiesCreator
 
   def doc
     document = VCR.use_cassette('docs/create') do
-      CodaDocs::Entities::Docs.new(@access_token).create
+      CodaDocs::Entities::Docs.new(@access_token).create({})
     end
   end
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,6 +1,6 @@
 require 'vcr'
 
-DOCS_URL = 'https://coda.io/apis/v1beta1/docs'
+DOCS_URL = 'https://coda.io/apis/v1/docs'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'


### PR DESCRIPTION
This PR updates specs/fixtures to make sure they pass on the current version of supported ruby (2.5) before migrating to ruby 3

- Fix cassette urls
- Fix calls to methods with no named arguments
- Add missing env variables if they arent there
- Fix call that required an option param
- Update gitignore
